### PR TITLE
Remove overrides from package.json

### DIFF
--- a/AshesFromChildhood/package.json
+++ b/AshesFromChildhood/package.json
@@ -31,9 +31,6 @@
   },
    "peerDependencies": {
     "three": "0.169.0"
-  },
-  "overrides": {
-    "three": "0.169.0",
-    "three-mesh-bvh": "0.8.0"
   }
+
 }


### PR DESCRIPTION
Deleted the 'overrides' section specifying versions for 'three' and 'three-mesh-bvh' to rely on default dependency resolution.